### PR TITLE
Add backup settings and refactor file exclusion logic

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -138,5 +138,8 @@
     "style_note_title_margin_desc": "Set the margin for the note title",
     "style_note_title_padding_desc": "Set the padding for the note title",
     "style_note_date_font_size_desc": "Set the font size for the note date",
-    "style_note_folder_font_size_desc": "Set the font size for the folder path text"
+    "style_note_folder_font_size_desc": "Set the font size for the folder path text",
+    "backup_settings_heading": "Backup Settings",
+    "backup_max_files": "Maximum backup files",
+    "backup_max_files_desc": "Set the maximum number of backup files to keep, older backups beyond this limit will be automatically deleted"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -138,5 +138,8 @@
     "style_note_title_margin_desc": "设置笔记标题的外边距",
     "style_note_title_padding_desc": "设置笔记标题的内边距",
     "style_note_date_font_size_desc": "设置笔记日期的字体大小",
-    "style_note_folder_font_size_desc": "设置文件夹路径文字的字体大小"
+    "style_note_folder_font_size_desc": "设置文件夹路径文字的字体大小",
+    "backup_settings_heading": "备份设置",
+    "backup_max_files": "最大备份文件数量",
+    "backup_max_files_desc": "设置保留的备份文件最大数量，超过此数量的旧备份将被自动删除"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,14 @@ import "@/types";
 
 export default class StartPagePlugin extends Plugin {
 	settings: StartPageSettings;
+	backupDir: string = this.manifest.dir + "/backup";
 
 	async onload() {
 		await this.loadSettings();
 
 		this.settings.scrollPosition = 0;
 		this.saveSettings();
-		
+
 		// Use Obsidian's built-in language setting
 		const obsidianLang = getLanguage() || "en";
 		setLocale(obsidianLang);
@@ -38,7 +39,7 @@ export default class StartPagePlugin extends Plugin {
 			name: t("open_start_page"),
 			callback: () => {
 				this.activateStartPage();
-			}
+			},
 		});
 
 		this.addCommand({
@@ -46,7 +47,7 @@ export default class StartPagePlugin extends Plugin {
 			name: t("open_start_page_new_tab"),
 			callback: () => {
 				this.activateStartPageNewTab();
-			}
+			},
 		});
 
 		this.registerEvent(
@@ -55,12 +56,12 @@ export default class StartPagePlugin extends Plugin {
 					if (leaf && !leaf.view.getViewType().startsWith(VIEW_TYPE_START_PAGE)) {
 						const state = leaf.getViewState();
 						// If new empty tab, replace it with StartPage
-						if (state.type === 'empty' &&  !state.state?.file) {
+						if (state.type === "empty" && !state.state?.file) {
 							this.replaceWithStartPage(leaf);
 						}
 					}
 				}
-			})
+			}),
 		);
 
 		// Register file menu event for right-click context menu
@@ -69,23 +70,19 @@ export default class StartPagePlugin extends Plugin {
 				if (file instanceof TFile) {
 					this.addPinnedNoteMenuItem(menu, file);
 				}
-			})
+			}),
 		);
 	}
 
 	async loadSettings() {
-		// Backup current settings
 		await this.backupSettings();
 
 		const savedData = await this.loadData();
 
-		// Check if saved configuration exists
 		if (savedData && typeof savedData === "object") {
-			// Preserve user settings, merge possible missing fields
 			this.settings = {
 				...DEFAULT_SETTINGS,
 				...savedData,
-				// Ensure required fields exist and have correct types
 				pinnedNotes: Array.isArray(savedData.pinnedNotes) ? savedData.pinnedNotes : [],
 				recentNotesLimit: typeof savedData.recentNotesLimit === "number" ? savedData.recentNotesLimit : 10,
 				includeAllFilesInRecent: typeof savedData.includeAllFilesInRecent === "boolean" ? savedData.includeAllFilesInRecent : true,
@@ -102,26 +99,30 @@ export default class StartPagePlugin extends Plugin {
 				latestVersion: typeof savedData.latestVersion === "string" ? savedData.latestVersion : "",
 				searchExcludePaths: Array.isArray(savedData.excludeList) ? savedData.excludeList : [],
 				searchExcludeExtensions: Array.isArray(savedData.excludeExtensions) ? savedData.excludeExtensions : [],
-				pinnedNotesStyle: typeof savedData.pinnedNotesStyle === "object" ? { ...DEFAULT_SETTINGS.pinnedNotesStyle, ...savedData.pinnedNotesStyle } : { ...DEFAULT_SETTINGS.pinnedNotesStyle },
-				recentNotesStyle: typeof savedData.recentNotesStyle === "object" ? { ...DEFAULT_SETTINGS.recentNotesStyle, ...savedData.recentNotesStyle } : { ...DEFAULT_SETTINGS.recentNotesStyle },
+				pinnedNotesStyle:
+					typeof savedData.pinnedNotesStyle === "object"
+						? { ...DEFAULT_SETTINGS.pinnedNotesStyle, ...savedData.pinnedNotesStyle }
+						: { ...DEFAULT_SETTINGS.pinnedNotesStyle },
+				recentNotesStyle:
+					typeof savedData.recentNotesStyle === "object"
+						? { ...DEFAULT_SETTINGS.recentNotesStyle, ...savedData.recentNotesStyle }
+						: { ...DEFAULT_SETTINGS.recentNotesStyle },
+				backupMaxFiles: typeof savedData.backupMaxFiles === "number" ? savedData.backupMaxFiles : DEFAULT_SETTINGS.backupMaxFiles,
 			};
 		} else {
-			// First installation or data corruption, use default settings
 			this.settings = { ...DEFAULT_SETTINGS };
 		}
+
+		await this.cleanupOldBackups();
 	}
 
-	/**
-	 * Create backup file for current configuration
-	 */
 	async backupSettings() {
-		const backupDir = this.manifest.dir + "/backup";
-		const backupFile = `${backupDir}/data-${new Date().toISOString().slice(0, 10)}.json`;
-		
+		const backupFile = `${this.backupDir}/data-${new Date().toISOString().slice(0, 10)}.json`;
+
 		const backupFileExists = await this.app.vault.adapter.exists(backupFile);
 		if (!backupFileExists) {
-			await this.app.vault.adapter.mkdir(backupDir);
-			
+			await this.app.vault.adapter.mkdir(this.backupDir);
+
 			const dataFile = this.manifest.dir + "/data.json";
 			if (await this.app.vault.adapter.exists(dataFile)) {
 				const dataContent = await this.app.vault.adapter.read(dataFile);
@@ -130,6 +131,54 @@ export default class StartPagePlugin extends Plugin {
 			} else {
 				console.log("data.json file does not exist, skipping backup");
 			}
+		}
+	}
+
+	private async cleanupOldBackups() {
+		try {
+			if (!(await this.app.vault.adapter.exists(this.backupDir))) {
+				return;
+			}
+
+			const files = await this.app.vault.adapter.list(this.backupDir);
+			const backupFiles = files.files.filter((file) => file.endsWith(".json") && file.includes("data-"));
+
+			if (backupFiles.length === 0) {
+				return;
+			}
+
+			const fileDatePairs = backupFiles
+				.map((file) => {
+					// Extract filename from path (works with both / and \ separators)
+					const lastSlashIndex = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
+					const fileName = lastSlashIndex >= 0 ? file.substring(lastSlashIndex + 1) : file;
+					const dateStr = fileName.replace("data-", "").replace(".json", "");
+					return {
+						file,
+						date: new Date(dateStr),
+						timestamp: new Date(dateStr).getTime(),
+					};
+				})
+				.filter((pair) => !isNaN(pair.timestamp));
+
+			// Sort by date (oldest first for deletion)
+			fileDatePairs.sort((a, b) => a.timestamp - b.timestamp);
+
+			// Delete oldest files beyond max limit
+			if (fileDatePairs.length > this.settings.backupMaxFiles) {
+				const filesToDelete = fileDatePairs.slice(0, fileDatePairs.length - this.settings.backupMaxFiles);
+
+				for (const pair of filesToDelete) {
+					try {
+						await this.app.vault.adapter.remove(pair.file);
+						console.log(`Deleted old backup file: ${pair.file}`);
+					} catch (error) {
+						console.error(`Failed to delete backup file ${pair.file}:`, error);
+					}
+				}
+			}
+		} catch (error) {
+			console.error("Error cleaning up backup files:", error);
 		}
 	}
 
@@ -186,21 +235,20 @@ export default class StartPagePlugin extends Plugin {
 
 	addPinnedNoteMenuItem(menu: Menu, file: TFile) {
 		const isPinned = this.settings.pinnedNotes.includes(file.path);
-		
+
 		menu.addItem((item) => {
-			item
-				.setTitle(isPinned ? t("remove_from_pinned_notes") : t("add_to_pinned_notes"))
+			item.setTitle(isPinned ? t("remove_from_pinned_notes") : t("add_to_pinned_notes"))
 				.setIcon(isPinned ? "pin-off" : "pin")
 				.onClick(async () => {
 					if (isPinned) {
 						// Remove from pinned notes
-						this.settings.pinnedNotes = this.settings.pinnedNotes.filter(path => path !== file.path);
+						this.settings.pinnedNotes = this.settings.pinnedNotes.filter((path) => path !== file.path);
 					} else {
 						// Add to pinned notes
 						this.settings.pinnedNotes.push(file.path);
 					}
 					await this.saveSettings();
-					
+
 					// Refresh start page if it's open
 					const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_START_PAGE);
 					leaves.forEach((leaf) => {
@@ -230,7 +278,7 @@ export default class StartPagePlugin extends Plugin {
 
 		try {
 			const versionInfo = await VersionChecker.checkForUpdate(this.manifest.version);
-			
+
 			if (versionInfo && versionInfo.hasUpdate) {
 				this.settings.latestVersion = versionInfo.latestVersion;
 				this.settings.lastVersionCheck = now;

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface StartPageSettings {
 	searchExcludeExtensions: string[]; // List of file extensions to exclude from search
 	pinnedNotesStyle: SectionStyleSettings;
 	recentNotesStyle: SectionStyleSettings;
+	backupMaxFiles: number; // Maximum number of backup files to keep
 }
 
 export const DEFAULT_SETTINGS: StartPageSettings = {
@@ -102,4 +103,5 @@ export const DEFAULT_SETTINGS: StartPageSettings = {
 	searchExcludeExtensions: [],
 	pinnedNotesStyle: { ...DEFAULT_SECTION_STYLE },
 	recentNotesStyle: { ...DEFAULT_SECTION_STYLE },
+	backupMaxFiles: 5,
 };

--- a/src/utils/myutil.ts
+++ b/src/utils/myutil.ts
@@ -1,41 +1,43 @@
-
 import { t } from "../i18n";
+import { StartPageSettings } from "@/types";
+import { App, TFile } from "obsidian";
+import { StartPageView, VIEW_TYPE_START_PAGE } from "@/views/startpageview";
 
 export class MyUtil {
-    /**
-     * 将路径字符串进行中间省略，保留头尾以提升可读性
-     */
-    static truncateMiddle(str: string, head: number = 24, tail: number = 16): string {
-        if (!str) return str;
-        const len = str.length;
-        if (len <= head + tail + 3) return str;
-        const start = str.slice(0, head);
-        const end = str.slice(-tail);
-        return `${start}...${end}`;
-    }
+	/**
+	 * 将路径字符串进行中间省略，保留头尾以提升可读性
+	 */
+	static truncateMiddle(str: string, head: number = 24, tail: number = 16): string {
+		if (!str) return str;
+		const len = str.length;
+		if (len <= head + tail + 3) return str;
+		const start = str.slice(0, head);
+		const end = str.slice(-tail);
+		return `${start}...${end}`;
+	}
 
-    /**
-     * 获取笔记所属目录路径；根目录返回 "/"
-     */
-    static getDirPath(p: string): string {
-        if (!p) return "/";
-        const idx = p.lastIndexOf("/");
-        if (idx === -1) return "/";
-        const dir = p.slice(0, idx);
-        return "/" + dir;
-    }
+	/**
+	 * 获取笔记所属目录路径；根目录返回 "/"
+	 */
+	static getDirPath(p: string): string {
+		if (!p) return "/";
+		const idx = p.lastIndexOf("/");
+		if (idx === -1) return "/";
+		const dir = p.slice(0, idx);
+		return "/" + dir;
+	}
 
-    /**
-     * 获取文件名（不包括扩展名）
-     */
+	/**
+	 * 获取文件名（不包括扩展名）
+	 */
 	static getFileNameWithoutExtension(fileName: string): string {
 		return fileName.slice(0, fileName.lastIndexOf("."));
 	}
 
-    /**
-     * 格式化时间戳为相对时间
-     */
-    static formatDate(timestamp: number): string {
+	/**
+	 * 格式化时间戳为相对时间
+	 */
+	static formatDate(timestamp: number): string {
 		const date = new Date(timestamp);
 		const now = new Date();
 		const diff = now.getTime() - date.getTime();
@@ -67,9 +69,9 @@ export class MyUtil {
 		});
 	}
 
-    /**
-     * 格式化文件大小
-     */
+	/**
+	 * 格式化文件大小
+	 */
 	static formatSize(size: number): string {
 		if (size < 1024) {
 			return size + "B";
@@ -80,5 +82,40 @@ export class MyUtil {
 		} else {
 			return (size / (1024 * 1024 * 1024)).toFixed(0) + "GB";
 		}
+	}
+
+	static isFileExcluded(settings: StartPageSettings, file: TFile): boolean {
+		const excludeList = settings.searchExcludePaths;
+		for (const excludePath of excludeList) {
+			// Check if the file path exactly matches
+			if (file.path === excludePath) {
+				return true;
+			}
+
+			// Check if the file is in an excluded folder
+			if (file.path.startsWith(excludePath + "/")) {
+				return true;
+			}
+		}
+
+		// Check if file extension is excluded
+		const excludeExtensions = settings.searchExcludeExtensions;
+		if (excludeExtensions.length > 0) {
+			const fileExt = file.extension.toLowerCase();
+			if (excludeExtensions.includes(fileExt)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static refreshStartPage(app: App) {
+		const leaves = app.workspace.getLeavesOfType(VIEW_TYPE_START_PAGE);
+		leaves.forEach((leaf) => {
+			if (leaf.view instanceof StartPageView) {
+				leaf.view.renderContent();
+			}
+		});
 	}
 }

--- a/src/views/searchmodal.ts
+++ b/src/views/searchmodal.ts
@@ -105,7 +105,7 @@ export default class SearchModal extends Modal {
 			if (this.caseSensitive) {
 				this.filteredResults = this.allFiles.filter((file) => {
 					// Check if file is excluded
-					if (this.isFileExcluded(file)) {
+					if (MyUtil.isFileExcluded(this.plugin.settings, file)) {
 						return false;
 					}
 					
@@ -130,7 +130,7 @@ export default class SearchModal extends Modal {
 				const lowerCaseQuery = query.toLowerCase();
 				this.filteredResults = this.allFiles.filter((file) => {
 					// Check if file is excluded
-					if (this.isFileExcluded(file)) {
+					if (MyUtil.isFileExcluded(this.plugin.settings, file)) {
 						return false;
 					}
 					
@@ -328,32 +328,6 @@ export default class SearchModal extends Modal {
 		}
 		
 		return null;
-	}
-
-	private isFileExcluded(file: TFile): boolean {
-		const excludeList = this.plugin.settings.searchExcludePaths;
-		for (const excludePath of excludeList) {
-			// Check if the file path exactly matches
-			if (file.path === excludePath) {
-				return true;
-			}
-
-			// Check if the file is in an excluded folder
-			if (file.path.startsWith(excludePath + "/")) {
-				return true;
-			}
-		}
-
-		// Check if file extension is excluded
-		const excludeExtensions = this.plugin.settings.searchExcludeExtensions;
-		if (excludeExtensions.length > 0) {
-			const fileExt = file.extension.toLowerCase();
-			if (excludeExtensions.includes(fileExt)) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private getExcludeTooltip(): string {

--- a/src/views/startpagesettingtab.ts
+++ b/src/views/startpagesettingtab.ts
@@ -59,6 +59,7 @@ export class StartPageSettingTab extends PluginSettingTab {
         this.createStyleSettings(containerEl);
         this.createNewTabSettings(containerEl);
         this.createSearchSettings(containerEl);
+        this.createBackupSettings(containerEl);
         this.createPinnedNotesSettings(containerEl);
         this.createFooterSettings(containerEl);
 
@@ -181,6 +182,26 @@ export class StartPageSettingTab extends PluginSettingTab {
                             this.display();
                         }).open();
                     });
+            });
+    }
+
+    private createBackupSettings(containerEl: HTMLElement) {
+        new Setting(containerEl)
+            .setName(t("backup_settings_heading"))
+            .setHeading();
+
+        new Setting(containerEl)
+            .setName(t("backup_max_files"))
+            .setDesc(t("backup_max_files_desc"))
+            .addDropdown((dropdown) => {
+                for (let i = 1; i <= 20; i++) {
+                    dropdown.addOption(i.toString(), i.toString());
+                }
+                dropdown.setValue(this.plugin.settings.backupMaxFiles.toString());
+                dropdown.onChange(async (value) => {
+                    this.plugin.settings.backupMaxFiles = parseInt(value);
+                    await this.plugin.saveSettings();
+                });
             });
     }
 

--- a/src/views/startpagesettingtab.ts
+++ b/src/views/startpagesettingtab.ts
@@ -5,6 +5,7 @@ import { t } from "@/i18n";
 import StyleSettingsModal from "@/views/stylesettingsmodal";
 import SearchExclusionModal from "@/views/searchexclusionmodal";
 import PinnedNotesModal from "@/views/pinnednotesmodal";
+import { MyUtil } from "@/utils/myutil";
 
 export class StartPageSettingTab extends PluginSettingTab {
 	plugin: StartPagePlugin;
@@ -14,15 +15,6 @@ export class StartPageSettingTab extends PluginSettingTab {
 	constructor(app: App, plugin: StartPagePlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
-	}
-
-	private refreshStartPage() {
-		const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_START_PAGE);
-		leaves.forEach((leaf) => {
-			if (leaf.view instanceof StartPageView) {
-				leaf.view.renderContent();
-			}
-		});
 	}
 
 	private updateTitleNavigationBar() {
@@ -80,7 +72,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 				toggle.onChange(async (value) => {
 					this.plugin.settings.includeAllFilesInRecent = value;
 					await this.plugin.saveSettings();
-					this.refreshStartPage();
+					MyUtil.refreshStartPage(this.app);
 				});
 			});
 
@@ -95,7 +87,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 				dropdown.onChange(async (value) => {
 					this.plugin.settings.recentNotesLimit = parseInt(value);
 					await this.plugin.saveSettings();
-					this.refreshStartPage();
+					MyUtil.refreshStartPage(this.app);
 				});
 			});
     }
@@ -126,7 +118,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 				toggle.onChange(async (value) => {
 					this.plugin.settings.showStatBar = value;
 					await this.plugin.saveSettings();
-					this.refreshStartPage();
+					MyUtil.refreshStartPage(this.app);
 				});
 			});
     }
@@ -140,7 +132,7 @@ export class StartPageSettingTab extends PluginSettingTab {
                     .setButtonText(t("style_settings_open_button"))
                     .onClick(() => {
                         new StyleSettingsModal(this.app, this.plugin, () => {
-                            this.refreshStartPage();
+                            MyUtil.refreshStartPage(this.app);
                         }).open();
                     });
             });
@@ -180,6 +172,7 @@ export class StartPageSettingTab extends PluginSettingTab {
                     .onClick(() => {
                         new SearchExclusionModal(this.app, this.plugin, () => {
                             this.display();
+							MyUtil.refreshStartPage(this.app);
                         }).open();
                     });
             });
@@ -223,7 +216,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 					}
 					await this.plugin.saveSettings();
 					this.updateFootComponentDisabledState();
-					this.refreshStartPage();
+					MyUtil.refreshStartPage(this.app);
 				});
 			});
 
@@ -237,7 +230,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 					this.plugin.settings.useRandomFooterText = value;
 					await this.plugin.saveSettings();
 					this.updateFootComponentDisabledState();
-					this.refreshStartPage();
+					MyUtil.refreshStartPage(this.app);
 				});
 			});
 
@@ -251,7 +244,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 					this.plugin.settings.customFooterText = value;
 					await this.plugin.saveSettings();
 					this.updateFootComponentDisabledState();
-					this.refreshStartPage();
+					MyUtil.refreshStartPage(this.app);
 				});
 			});
     }
@@ -279,7 +272,7 @@ export class StartPageSettingTab extends PluginSettingTab {
                     .setCta()
                     .onClick(() => {
                         new PinnedNotesModal(this.app, this.plugin, () => {
-                            this.refreshStartPage();
+                            MyUtil.refreshStartPage(this.app);
                             this.display();
                         }).open();
                     });

--- a/src/views/startpageview.ts
+++ b/src/views/startpageview.ts
@@ -2,6 +2,7 @@ import { App, ItemView, TFile, Menu, EventRef, Platform, debounce } from "obsidi
 import StartPagePlugin from "@/main";
 import { t } from "@/i18n";
 import StartPageCreator from "@/core/startpagecreator";
+import { MyUtil } from "@/utils/myutil";
 
 export const VIEW_TYPE_START_PAGE = "start-page-view";
 
@@ -216,7 +217,9 @@ export class StartPageView extends ItemView {
 	getRecentNotes(limit: number): TFile[] {
 		const recentlyOpenedPaths = this.app.workspace.getLastOpenFiles();
 
-		const allFiles = this.plugin.settings.includeAllFilesInRecent ? this.app.vault.getFiles() : this.app.vault.getMarkdownFiles();
+		const allFiles = (this.plugin.settings.includeAllFilesInRecent ? this.app.vault.getFiles() : this.app.vault.getMarkdownFiles()).filter(
+			(file) => !MyUtil.isFileExcluded(this.plugin.settings, file),
+		);
 
 		if (allFiles.length === 0) {
 			return [];


### PR DESCRIPTION
# feat(backup): add backup settings with automatic cleanup
Add backup settings UI to control maximum number of backup files to keep. Implement automatic cleanup of old backups when exceeding the limit. The feature includes:
- New backup settings section in UI
- Backup file management logic
- Localization support for multiple languages

# refactor(file-exclusion): move file exclusion logic to MyUtil class

- Centralize file exclusion logic in MyUtil to avoid code duplication and improve maintainability. Also move refreshStartPage functionality to MyUtil for consistency.