### PR TITLE
chore: clean up redundant comments and update project metadata

### DIFF
--- a/env-example.json
+++ b/env-example.json
@@ -1,3 +1,3 @@
 {
-  "OBSIDIAN_PLUGIN_DIR": "C:/Users/Administrator/Documents/Obsidian Vault/.obsidian/plugins/obsidian-startpage"
+  "OBSIDIAN_PLUGIN_DIR": "C:/Users/kuzzh/Documents/Obsidian Vault/.obsidian/plugins/obsidian-startpage"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "obsidian-sample-plugin",
-	"version": "1.0.0",
+	"name": "obsidian-startpage",
+	"version": "0.3.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-sample-plugin",
-			"version": "1.0.0",
+			"name": "obsidian-startpage",
+			"version": "0.3.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/src/core/startpagecreator.ts
+++ b/src/core/startpagecreator.ts
@@ -22,7 +22,7 @@ export default class StartPageCreator {
 	private plugin: StartPagePlugin;
 	private container: Element;
 	private searchBox: HTMLInputElement;
-	private globalKeyHandler: (e: KeyboardEvent) => void;
+	private keyHandler: (e: KeyboardEvent) => void;
 	private initialQuery: string = "";
 	private stats = [
 		{
@@ -76,11 +76,17 @@ export default class StartPageCreator {
 		this.container.appendChild(mainContent);
 		this.container.appendChild(footer);
 
-		this.setupGlobalKeyListener();
+		this.setupKeyListener();
+
+		(this.container as HTMLElement).tabIndex = -1;
+	}
+
+	public focusContainer(): void {
+		(this.container as HTMLElement).focus();
 	}
 
 	public destroy(): void {
-		this.removeGlobalKeyListener();
+		this.removeKeyListener();
 	}
 
 	private initData(pinnedNotes: TFile[] | null, recentNotes: TFile[] | null): void {
@@ -111,7 +117,6 @@ export default class StartPageCreator {
 	private createHeader(): HTMLElement {
 		const header = this.createElement("header", "header");
 
-		// Logo
 		const logo = this.createElement("div", "logo");
 		const logoIcon = SvgUtil.createLogoIcon();
 		const logoText = this.createElement("span", "logo-text", "Start Page for Obsidian");
@@ -134,10 +139,8 @@ export default class StartPageCreator {
 		logo.appendChild(logoText);
 		logo.appendChild(searchBoxContainer);
 
-		// Header actions (Update badge if available)
 		const headerActions = this.createElement("div", "header-actions");
 
-		// Check if there's a new version available
 		if (this.hasUpdate()) {
 			const updateBadge = this.createUpdateBadge();
 			headerActions.appendChild(updateBadge);
@@ -169,7 +172,6 @@ export default class StartPageCreator {
 			statsSection.appendChild(statCard);
 
 			statCard.addEventListener("click", () => {
-				// open search modal
 				this.showSearchModal();
 			});
 		});
@@ -203,7 +205,6 @@ export default class StartPageCreator {
 			}
 		});
 
-		// 添加 hover preview 功能
 		noteItem.addEventListener("mouseenter", (event) => {
 			this.app.workspace.trigger("hover-link", {
 				event: event as MouseEvent,
@@ -482,26 +483,23 @@ export default class StartPageCreator {
 		return totalSize;
 	}
 
-	private setupGlobalKeyListener(): void {
-		this.globalKeyHandler = (e: KeyboardEvent) => {
-			// 检查当前活动视图是否是 start page
-			const activeView = this.app.workspace.getActiveViewOfType(StartPageView);
-			if (!activeView) {
-				return;
-			}
-
-			// 排除功能键和组合键
+	private setupKeyListener(): void {
+		this.keyHandler = (e: KeyboardEvent) => {
 			if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) {
 				return;
 			}
 
-			// 只处理可打印字符（字母、数字等）
 			if (e.key.length !== 1) {
 				return;
 			}
 
-			// 排除在输入框中输入的情况
-			if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+			const target = e.target as Node;
+			if (
+				target instanceof HTMLInputElement ||
+				target instanceof HTMLTextAreaElement ||
+				target instanceof HTMLSelectElement ||
+				(target instanceof HTMLElement && target.isContentEditable)
+			) {
 				return;
 			}
 
@@ -510,21 +508,15 @@ export default class StartPageCreator {
 			}
 
 			this.initialQuery = e.key;
-
 			this.showSearchModal();
-
 			e.preventDefault();
 			e.stopPropagation();
 		};
 
-		document.addEventListener("keydown", this.globalKeyHandler, true);
+		(this.container as HTMLElement).addEventListener("keydown", this.keyHandler);
 	}
 
 	private showSearchModal(): void {
-		if (document.querySelector('.modal-container')) {
-			return;
-		}
-
 		const modal = new SearchModal(
 			this.app,
 			this.plugin,
@@ -537,15 +529,12 @@ export default class StartPageCreator {
 		this.initialQuery = "";
 	}
 
-	private removeGlobalKeyListener(): void {
-		if (this.globalKeyHandler) {
-			document.removeEventListener("keydown", this.globalKeyHandler, true);
+	private removeKeyListener(): void {
+		if (this.keyHandler) {
+			(this.container as HTMLElement).removeEventListener("keydown", this.keyHandler);
 		}
 	}
 
-	/**
-	 * Check if there's a new version available
-	 */
 	private hasUpdate(): boolean {
 		const currentVersion = this.plugin.manifest.version;
 		const latestVersion = this.plugin.settings.latestVersion;
@@ -554,7 +543,6 @@ export default class StartPageCreator {
 			return false;
 		}
 
-		// Simple version comparison
 		const current = currentVersion.split(".").map(Number);
 		const latest = latestVersion.split(".").map(Number);
 
@@ -568,9 +556,6 @@ export default class StartPageCreator {
 		return false;
 	}
 
-	/**
-	 * Create update badge element
-	 */
 	private createUpdateBadge(): HTMLElement {
 		const badge = this.createElement("div", "update-badge");
 		badge.setAttribute("title", t("new_version_available"));

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,24 +16,19 @@ export default class StartPagePlugin extends Plugin {
 		this.settings.scrollPosition = 0;
 		this.saveSettings();
 
-		// Use Obsidian's built-in language setting
 		const obsidianLang = getLanguage() || "en";
 		setLocale(obsidianLang);
 
 		this.registerView(VIEW_TYPE_START_PAGE, (leaf) => new StartPageView(leaf, this.app, this));
 
-		// Check for updates in background
 		this.checkForUpdates();
 
-		// Add ribbon button
 		this.addRibbonIcon("home", "Open start page", () => {
 			this.activateStartPage();
 		});
 
-		// Add settings tab
 		this.addSettingTab(new StartPageSettingTab(this.app, this));
 
-		// Add commands
 		this.addCommand({
 			id: "open-start-page",
 			name: t("open_start_page"),
@@ -55,7 +50,6 @@ export default class StartPagePlugin extends Plugin {
 				if (this.settings.replaceNewTab) {
 					if (leaf && !leaf.view.getViewType().startsWith(VIEW_TYPE_START_PAGE)) {
 						const state = leaf.getViewState();
-						// If new empty tab, replace it with StartPage
 						if (state.type === "empty" && !state.state?.file) {
 							this.replaceWithStartPage(leaf);
 						}
@@ -64,7 +58,6 @@ export default class StartPagePlugin extends Plugin {
 			}),
 		);
 
-		// Register file menu event for right-click context menu
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu: Menu, file: TFile) => {
 				if (file instanceof TFile) {
@@ -149,7 +142,6 @@ export default class StartPagePlugin extends Plugin {
 
 			const fileDatePairs = backupFiles
 				.map((file) => {
-					// Extract filename from path (works with both / and \ separators)
 					const lastSlashIndex = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
 					const fileName = lastSlashIndex >= 0 ? file.substring(lastSlashIndex + 1) : file;
 					const dateStr = fileName.replace("data-", "").replace(".json", "");
@@ -161,10 +153,8 @@ export default class StartPagePlugin extends Plugin {
 				})
 				.filter((pair) => !isNaN(pair.timestamp));
 
-			// Sort by date (oldest first for deletion)
 			fileDatePairs.sort((a, b) => a.timestamp - b.timestamp);
 
-			// Delete oldest files beyond max limit
 			if (fileDatePairs.length > this.settings.backupMaxFiles) {
 				const filesToDelete = fileDatePairs.slice(0, fileDatePairs.length - this.settings.backupMaxFiles);
 
@@ -241,15 +231,12 @@ export default class StartPagePlugin extends Plugin {
 				.setIcon(isPinned ? "pin-off" : "pin")
 				.onClick(async () => {
 					if (isPinned) {
-						// Remove from pinned notes
 						this.settings.pinnedNotes = this.settings.pinnedNotes.filter((path) => path !== file.path);
 					} else {
-						// Add to pinned notes
 						this.settings.pinnedNotes.push(file.path);
 					}
 					await this.saveSettings();
 
-					// Refresh start page if it's open
 					const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_START_PAGE);
 					leaves.forEach((leaf) => {
 						if (leaf.view instanceof StartPageView) {
@@ -264,14 +251,10 @@ export default class StartPagePlugin extends Plugin {
 		this.app.workspace.getLeavesOfType(VIEW_TYPE_START_PAGE).forEach((leaf) => leaf.detach());
 	}
 
-	/**
-	 * Check for plugin updates in background
-	 */
 	async checkForUpdates() {
 		const now = Date.now();
-		const ONE_DAY = 24 * 60 * 60 * 1000; // 24 hours
+		const ONE_DAY = 24 * 60 * 60 * 1000;
 
-		// Check once per day
 		if (now - this.settings.lastVersionCheck < ONE_DAY) {
 			return;
 		}
@@ -284,7 +267,6 @@ export default class StartPagePlugin extends Plugin {
 				this.settings.lastVersionCheck = now;
 				await this.saveSettings();
 
-				// Refresh start page views to show the update badge
 				const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_START_PAGE);
 				leaves.forEach((leaf) => {
 					if (leaf.view instanceof StartPageView) {
@@ -292,7 +274,6 @@ export default class StartPagePlugin extends Plugin {
 					}
 				});
 			} else {
-				// No update, just update the check timestamp
 				this.settings.lastVersionCheck = now;
 				await this.saveSettings();
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,35 +12,27 @@ export const ID_STAT_TODAY_EDITED = "todayEdited";
 export const ID_STAT_TOTAL_SIZE = "totalSize";
 
 export interface SectionStyleSettings {
-	// section container
 	sectionMargin: string;
 	sectionPadding: string;
 	
-	// section header
 	headerMargin: string;
 	headerPadding: string;
 	
-	// section title
 	titleFontSize: string;
 	titleMargin: string;
 	titlePadding: string;
 	
-	// notes list
 	listGap: string;
 	
-	// note item
 	itemPadding: string;
 	itemMargin: string;
 	
-	// note title
 	noteTitleFontSize: string;
 	noteTitleMargin: string;
 	noteTitlePadding: string;
 	
-	// note date
 	noteDateFontSize: string;
 	
-	// note folder
 	noteFolderFontSize: string;
 }
 
@@ -70,18 +62,18 @@ export interface StartPageSettings {
 	showTitleNavigationBar: "default" | "show" | "hide";
 	showCustomFooterText: boolean;
 	useRandomFooterText: boolean;
-	todayRandomEnFooterText: string; // 今日英文随机脚本文字,格式:2025118|I think,there for I am.
-	todayRandomZhFooterText: string; // 今日中文随机脚本文字,格式:2025118|百日依山尽,黄河入海流
+	todayRandomEnFooterText: string; 
+	todayRandomZhFooterText: string; 
 	customFooterText: string;
-	scrollPosition: number; // Scroll position for start page
+	scrollPosition: number; 
 	showStatBar: boolean;
-	lastVersionCheck: number; // Last time version check was performed
-	latestVersion: string; // Latest version from GitHub
-	searchExcludePaths: string[]; // List of files/folders to exclude from search
-	searchExcludeExtensions: string[]; // List of file extensions to exclude from search
+	lastVersionCheck: number; 
+	latestVersion: string;
+	searchExcludePaths: string[]; 
+	searchExcludeExtensions: string[];
 	pinnedNotesStyle: SectionStyleSettings;
 	recentNotesStyle: SectionStyleSettings;
-	backupMaxFiles: number; // Maximum number of backup files to keep
+	backupMaxFiles: number;
 }
 
 export const DEFAULT_SETTINGS: StartPageSettings = {

--- a/src/utils/footertextutil.ts
+++ b/src/utils/footertextutil.ts
@@ -9,15 +9,12 @@ const QUOTE_API_URL_ZH = "https://v2.jinrishici.com/one.json?client=browser-sdk/
 export default class FooterTextUtil {
     static async getFooterText(plugin: StartPagePlugin): Promise<string> {
         const settings: StartPageSettings = plugin.settings;
-        // 如果没有启用自定义文本，返回默认文本
         if (!settings.showCustomFooterText) {
             return t("default_footer_text");
         }
-        // 如果不使用随机文本，返回自定义文本或默认文本
         if (!settings.useRandomFooterText) {
             return settings.customFooterText || t("default_footer_text");
         }
-        // 如果使用随机文本，根据语言返回随机文本
         const obsidianLang = getLanguage() || "en";
         if (obsidianLang === "zh") {
             return await FooterTextUtil.getChineseRandomFooterText(plugin);
@@ -26,37 +23,6 @@ export default class FooterTextUtil {
         }
     }
 
-    //     {
-    //     "status": "success",
-    //     "data": {
-    //         "id": "5b8b9572e116fb3714e7378b",
-    //         "content": "塞上秋风鼓角，城头落日旌旗。",
-    //         "popularity": 18600,
-    //         "origin": {
-    //             "title": "江月晃重山·初到嵩山时作",
-    //             "dynasty": "金朝",
-    //             "author": "元好问",
-    //             "content": [
-    //                 "塞上秋风鼓角，城头落日旌旗。少年鞍马适相宜。从军乐，莫问所从谁。",
-    //                 "侯骑才通蓟北，先声已动辽西。归期犹及柳依依。春闺月，红袖不须啼。"
-    //             ],
-    //             "translate": [
-    //                 "军队中的鼓声、角声在秋风中作响，城头上的旗帜在夕阳的照耀下缓缓地飘动。 少年应当从军，身跨战马，驰骋边关。只要能够从军驰骋就十分快乐，并不要在乎由谁来带兵。",
-    //                 "侦察的骑兵才通过蓟北，而部队的威名已震动辽西。等打完仗，回到故乡时，仍是杨柳依依的春天，时间不会太长。 征人连战连胜，可以很快凯旋，闺中人不必因相思而流泪。"
-    //             ]
-    //         },
-    //         "matchTags": [
-    //             "日落",
-    //             "秋",
-    //             "风"
-    //         ],
-    //         "recommendedReason": "",
-    //         "cacheAt": "2025-11-17T17:59:04.520048707"
-    //     },
-    //     "token": "3hCO1PU/EYmrHz/DNlP9baTHG8IgwXLd",
-    //     "ipAddress": "182.151.174.106",
-    //     "warning": null
-    // }
     static async getChineseRandomFooterText(plugin: StartPagePlugin): Promise<string> {
         const settings: StartPageSettings = plugin.settings;
 
@@ -84,13 +50,6 @@ export default class FooterTextUtil {
         return t("default_footer_text");
     }
 
-    // [
-    //   {
-    //     "q": "It's not what happens to you, but how you react to it that matters.",
-    //     "a": "Epictetus",
-    //     "h": "\u003Cblockquote\u003E&ldquo;It's not what happens to you, but how you react to it that matters.&rdquo; &mdash; \u003Cfooter\u003EEpictetus\u003C/footer\u003E\u003C/blockquote\u003E"
-    //   }
-    // ]
     static async getEnglishRandomFooterText(plugin: StartPagePlugin): Promise<string> {
         const settings: StartPageSettings = plugin.settings;
         const today: string = new Date().toISOString().slice(0, 10);

--- a/src/utils/myutil.ts
+++ b/src/utils/myutil.ts
@@ -4,9 +4,6 @@ import { App, TFile } from "obsidian";
 import { StartPageView, VIEW_TYPE_START_PAGE } from "@/views/startpageview";
 
 export class MyUtil {
-	/**
-	 * 将路径字符串进行中间省略，保留头尾以提升可读性
-	 */
 	static truncateMiddle(str: string, head: number = 24, tail: number = 16): string {
 		if (!str) return str;
 		const len = str.length;
@@ -16,9 +13,6 @@ export class MyUtil {
 		return `${start}...${end}`;
 	}
 
-	/**
-	 * 获取笔记所属目录路径；根目录返回 "/"
-	 */
 	static getDirPath(p: string): string {
 		if (!p) return "/";
 		const idx = p.lastIndexOf("/");
@@ -27,22 +21,15 @@ export class MyUtil {
 		return "/" + dir;
 	}
 
-	/**
-	 * 获取文件名（不包括扩展名）
-	 */
 	static getFileNameWithoutExtension(fileName: string): string {
 		return fileName.slice(0, fileName.lastIndexOf("."));
 	}
 
-	/**
-	 * 格式化时间戳为相对时间
-	 */
 	static formatDate(timestamp: number): string {
 		const date = new Date(timestamp);
 		const now = new Date();
 		const diff = now.getTime() - date.getTime();
 
-		// Less than 24 hours
 		if (diff < 24 * 60 * 60 * 1000) {
 			const hours = Math.floor(diff / (60 * 60 * 1000));
 			if (hours === 0) {
@@ -52,13 +39,11 @@ export class MyUtil {
 			return t("hours_ago").replace("{hours}", hours.toString());
 		}
 
-		// Less than 7 days
 		if (diff < 7 * 24 * 60 * 60 * 1000) {
 			const days = Math.floor(diff / (24 * 60 * 60 * 1000));
 			return t("days_ago").replace("{days}", days.toString());
 		}
 
-		// Otherwise show full date
 		return date.toLocaleDateString("zh-CN", {
 			year: "numeric",
 			month: "2-digit",
@@ -69,9 +54,6 @@ export class MyUtil {
 		});
 	}
 
-	/**
-	 * 格式化文件大小
-	 */
 	static formatSize(size: number): string {
 		if (size < 1024) {
 			return size + "B";
@@ -87,18 +69,15 @@ export class MyUtil {
 	static isFileExcluded(settings: StartPageSettings, file: TFile): boolean {
 		const excludeList = settings.searchExcludePaths;
 		for (const excludePath of excludeList) {
-			// Check if the file path exactly matches
 			if (file.path === excludePath) {
 				return true;
 			}
 
-			// Check if the file is in an excluded folder
 			if (file.path.startsWith(excludePath + "/")) {
 				return true;
 			}
 		}
 
-		// Check if file extension is excluded
 		const excludeExtensions = settings.searchExcludeExtensions;
 		if (excludeExtensions.length > 0) {
 			const fileExt = file.extension.toLowerCase();

--- a/src/utils/svgutil.ts
+++ b/src/utils/svgutil.ts
@@ -244,11 +244,9 @@ export default class SvgUtil {
         ],
         "canvas": [
             { tagName: "rect", attributes: { x: "4", y: "3", width: "16", height: "20", rx: "2", stroke: "currentColor", "stroke-width": "2", fill: "none" } },
-            // Three bold nodes, spread out inside the rect
             { tagName: "circle", attributes: { cx: "8", cy: "9", r: "2", fill: "currentColor" } },
             { tagName: "circle", attributes: { cx: "16", cy: "9", r: "2", fill: "currentColor" } },
             { tagName: "circle", attributes: { cx: "12", cy: "17", r: "2", fill: "currentColor" } },
-            // Connecting lines
             { tagName: "path", attributes: { d: "M10 9L14 9", stroke: "currentColor", "stroke-width": "1.5", "stroke-linecap": "round" } },
             { tagName: "path", attributes: { d: "M9.4 10.6L12 15", stroke: "currentColor", "stroke-width": "1.5", "stroke-linecap": "round" } },
             { tagName: "path", attributes: { d: "M14.6 10.6L12 15", stroke: "currentColor", "stroke-width": "1.5", "stroke-linecap": "round" } }

--- a/src/utils/versionchecker.ts
+++ b/src/utils/versionchecker.ts
@@ -11,11 +11,6 @@ export class VersionChecker {
 	private static readonly GITHUB_API_URL = "https://api.github.com/repos/kuzzh/obsidian-startpage/releases/latest";
 	private static readonly GITHUB_RELEASE_URL = "https://github.com/kuzzh/obsidian-startpage/releases";
 	
-	/**
-	 * Check if there's a new version available
-	 * @param currentVersion Current plugin version
-	 * @returns Version information
-	 */
 	static async checkForUpdate(currentVersion: string): Promise<VersionInfo | null> {
 		try {
 			const response = await requestUrl({
@@ -53,12 +48,6 @@ export class VersionChecker {
 		}
 	}
 
-	/**
-	 * Compare two version strings
-	 * @param v1 Version 1
-	 * @param v2 Version 2
-	 * @returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal
-	 */
 	private static compareVersions(v1: string, v2: string): number {
 		const parts1 = v1.split(".").map(Number);
 		const parts2 = v2.split(".").map(Number);

--- a/src/views/filefoldersuggestmodal.ts
+++ b/src/views/filefoldersuggestmodal.ts
@@ -11,15 +11,12 @@ export default class FileFolderSuggestModal extends SuggestModal<TAbstractFile> 
 	getSuggestions(query: string): TAbstractFile[] {
 		const allItems: TAbstractFile[] = [];
 		
-		// Add all folders
 		const folders = this.app.vault.getAllLoadedFiles().filter(f => f instanceof TFolder);
 		allItems.push(...folders);
 		
-		// Add all files
 		const files = this.app.vault.getFiles();
 		allItems.push(...files);
 		
-		// Filter by query
 		return allItems.filter(item => 
 			item.path.toLowerCase().includes(query.toLowerCase())
 		);

--- a/src/views/pinnednotesmodal.ts
+++ b/src/views/pinnednotesmodal.ts
@@ -230,7 +230,6 @@ export default class PinnedNotesModal extends Modal {
 
 	private refreshDisplay() {
 		const { contentEl } = this;
-		// 保留标题，清空其他内容
 		const modalContent = contentEl.querySelector(".modal-content");
 		if (modalContent) {
 			modalContent.empty();

--- a/src/views/searchexclusionmodal.ts
+++ b/src/views/searchexclusionmodal.ts
@@ -17,7 +17,6 @@ export default class SearchExclusionModal extends Modal {
     onOpen() {
         const { contentEl } = this;
 
-        // 排除路径设置
         new Setting(contentEl)
             .setName(t("search_exclude_list"))
             .setDesc(t("search_exclude_list_desc"))
@@ -37,7 +36,6 @@ export default class SearchExclusionModal extends Modal {
 
         this.renderPathsList(contentEl);
 
-        // 排除扩展名设置
         new Setting(contentEl)
             .setName(t("search_exclude_extensions"))
             .setDesc(t("search_exclude_extensions_desc"))

--- a/src/views/searchmodal.ts
+++ b/src/views/searchmodal.ts
@@ -38,7 +38,6 @@ export default class SearchModal extends Modal {
 			this.performSearch(value);
 		});
 
-		// Exclude settings button
 		const excludeSettingsBtn = searchContainer.createEl("button", {
 			cls: "search-exclude-settings-btn",
 			attr: {
@@ -53,7 +52,6 @@ export default class SearchModal extends Modal {
 			this.openExcludeSettings();
 		});
 
-		// Case sensitivity toggle button
 		const caseSensitiveBtn = searchContainer.createEl("button", {
 			cls: "search-case-sensitive-btn",
 			attr: {
@@ -104,17 +102,14 @@ export default class SearchModal extends Modal {
 		} else {
 			if (this.caseSensitive) {
 				this.filteredResults = this.allFiles.filter((file) => {
-					// Check if file is excluded
 					if (MyUtil.isFileExcluded(this.plugin.settings, file)) {
 						return false;
 					}
 					
-					// Search in file name
 					if (file.name.includes(query)) {
 						return true;
 					}
 					
-					// Search in aliases
 					const cache = this.app.metadataCache.getFileCache(file);
 					const aliases = cache?.frontmatter?.aliases || cache?.frontmatter?.alias;
 					if (aliases) {
@@ -129,17 +124,14 @@ export default class SearchModal extends Modal {
 			} else {
 				const lowerCaseQuery = query.toLowerCase();
 				this.filteredResults = this.allFiles.filter((file) => {
-					// Check if file is excluded
 					if (MyUtil.isFileExcluded(this.plugin.settings, file)) {
 						return false;
 					}
 					
-					// Search in file name
 					if (file.name.toLowerCase().includes(lowerCaseQuery)) {
 						return true;
 					}
 					
-					// Search in aliases
 					const cache = this.app.metadataCache.getFileCache(file);
 					const aliases = cache?.frontmatter?.aliases || cache?.frontmatter?.alias;
 					if (aliases) {
@@ -184,7 +176,6 @@ export default class SearchModal extends Modal {
 			itemEl.setAttribute("title", fileNameWithoutExt);
 			itemEl.appendChild(fileNameEl);
 
-			// Check if file has matching aliases
 			const query = this.searchComponent.getValue();
 			const cache = this.app.metadataCache.getFileCache(file);
 			const aliases = cache?.frontmatter?.aliases || cache?.frontmatter?.alias;
@@ -221,7 +212,6 @@ export default class SearchModal extends Modal {
 				this.close();
 			});
 
-			// 添加 hover preview 功能
 			itemEl.addEventListener("mouseenter", (event) => {
 				this.app.workspace.trigger("hover-link", {
 					event: event as MouseEvent,
@@ -234,7 +224,6 @@ export default class SearchModal extends Modal {
 			});
 		}
 
-		// Set first item as active by default
 		if (this.filteredResults.length > 0) {
 			this.setActiveIndex(0);
 		}
@@ -246,7 +235,6 @@ export default class SearchModal extends Modal {
 				e.preventDefault();
 
 				if (this.filteredResults.length === 0) {
-					// Create a new note when no results
 					const query = this.searchComponent.getValue().trim();
 					if (query) {
 						this.createNewNote(query);
@@ -275,29 +263,23 @@ export default class SearchModal extends Modal {
 	setActiveIndex(index: number) {
 		const items = this.resultsContainer.querySelectorAll('.search-result-item');
 
-		// Remove active class from all items
 		items.forEach(item => item.removeClass('is-active'));
 
-		// Add active class to selected item
 		if (index >= 0 && index < items.length) {
 			this.selectedIndex = index;
 			items[index].addClass('is-active');
 
-			// Scroll item into view if needed
 			items[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 		}
 	}
 
 	async createNewNote(noteName: string) {
 		try {
-			// Sanitize the filename to remove invalid characters
 			const sanitizedName = noteName.replace(/[\\/:*?"<>|]/g, '');
 			const fileName = `${sanitizedName}.md`;
 
-			// Check if file already exists
 			const existingFile = this.app.vault.getAbstractFileByPath(fileName);
 			if (existingFile) {
-				// If file exists, just open it
 				if (existingFile instanceof TFile) {
 					await this.app.workspace.getLeaf().openFile(existingFile);
 				}
@@ -340,7 +322,6 @@ export default class SearchModal extends Modal {
 		
 		const items: string[] = [];
 		
-		// Add file/folder exclusions
 		if (excludeList.length > 0) {
 			const displayList = excludeList.length <= 2
 				? excludeList.join(", ")
@@ -348,7 +329,6 @@ export default class SearchModal extends Modal {
 			items.push(displayList);
 		}
 		
-		// Add extension exclusions
 		if (excludeExtensions.length > 0) {
 			const extDisplay = excludeExtensions.length <= 2
 				? excludeExtensions.map(ext => `.${ext}`).join(", ")
@@ -361,7 +341,6 @@ export default class SearchModal extends Modal {
 
 	private openExcludeSettings() {
 		this.close();
-		// Open settings tab and navigate to search section
 		(this.app as any).setting.open();
 		(this.app as any).setting.openTabById(this.plugin.manifest.id);
 	}

--- a/src/views/startpagesettingtab.ts
+++ b/src/views/startpagesettingtab.ts
@@ -26,7 +26,7 @@ export class StartPageSettingTab extends PluginSettingTab {
 					view.showTitleNavigationBar(true);
 				} else if (this.plugin.settings.showTitleNavigationBar === "hide") {
 					view.showTitleNavigationBar(false);
-				} else { // default
+				} else { 
 					view.showTitleNavigationBar(!Platform.isDesktop);
 				}
 			}

--- a/src/views/startpageview.ts
+++ b/src/views/startpageview.ts
@@ -13,7 +13,7 @@ export class StartPageView extends ItemView {
 	private fileDeleteEventRef: EventRef;
 	private fileRenameEventRef: EventRef;
 	private refreshTimer: number | null = null;
-	private readonly REFRESH_INTERVAL = 60000; // Refresh every 1 minute
+	private readonly REFRESH_INTERVAL = 60000;
 	private startPageCreator: StartPageCreator;
 	private isScrollEventRegistered = false;
 	private debouncedSaveScrollPosition: () => void;
@@ -27,7 +27,6 @@ export class StartPageView extends ItemView {
 		this.icon = "home";
 		this.contentEl.addClass("start-page-view");
 
-		// Create debounced function once during initialization
 		this.debouncedSaveScrollPosition = debounce(() => {
 			this.saveScrollPosition();
 		}, 300);
@@ -37,7 +36,6 @@ export class StartPageView extends ItemView {
 		} else if (this.plugin.settings.showTitleNavigationBar === "hide") {
 			this.showTitleNavigationBar(false);
 		} else {
-			// default
 			if (Platform.isDesktop) {
 				this.showTitleNavigationBar(false);
 			} else {
@@ -67,22 +65,42 @@ export class StartPageView extends ItemView {
 
 		this.restoreScrollPosition();
 
-		// Register file change events
+		this.startPageCreator?.focusContainer();
+
+		this.registerEvent(
+			this.app.workspace.on("active-leaf-change", (leaf) => {
+				if (leaf?.view instanceof StartPageView) {
+					this.startPageCreator?.focusContainer();
+				}
+			}),
+		);
+
 		this.fileChangeEventRef = this.app.vault.on("modify", () => {
 			this.renderContent();
+			if (this.app.workspace.getActiveViewOfType(StartPageView) === this) {
+				this.startPageCreator?.focusContainer();
+			}
 		});
 
-		// Add event listeners for file creation, deletion, and rename
 		this.fileCreateEventRef = this.app.vault.on("create", () => {
 			this.renderContent();
+			if (this.app.workspace.getActiveViewOfType(StartPageView) === this) {
+				this.startPageCreator?.focusContainer();
+			}
 		});
 
 		this.fileDeleteEventRef = this.app.vault.on("delete", () => {
 			this.renderContent();
+			if (this.app.workspace.getActiveViewOfType(StartPageView) === this) {
+				this.startPageCreator?.focusContainer();
+			}
 		});
 
 		this.fileRenameEventRef = this.app.vault.on("rename", () => {
 			this.renderContent();
+			if (this.app.workspace.getActiveViewOfType(StartPageView) === this) {
+				this.startPageCreator?.focusContainer();
+			}
 		});
 
 		this.registerDomEvent(this.containerEl, "contextmenu", (evt: MouseEvent) => {
@@ -100,7 +118,6 @@ export class StartPageView extends ItemView {
 		if (this.startPageCreator) {
 			this.startPageCreator.destroy();
 		}
-		// Clean up event listeners and timer when view is closed
 		if (this.fileChangeEventRef) {
 			this.app.vault.offref(this.fileChangeEventRef);
 		}
@@ -126,10 +143,9 @@ export class StartPageView extends ItemView {
 	private startRefreshTimerIfNeeded(pinnedNotes: TFile[], recentNotes: TFile[]) {
 		this.clearRefreshTimer();
 
-		// Check if there are any files that need to be refreshed every 24 hours
 		const needsRefresh = pinnedNotes.concat(recentNotes).some((file) => {
 			const diff = Date.now() - file.stat.mtime;
-			return diff < 24 * 60 * 60 * 1000; // Files modified within 24 hours need periodic refresh
+			return diff < 24 * 60 * 60 * 1000;
 		});
 
 		if (needsRefresh) {
@@ -189,7 +205,6 @@ export class StartPageView extends ItemView {
 	private restoreScrollPosition() {
 		const container = document.querySelector(".start-page-container") as HTMLElement;
 		if (container && this.plugin.settings.scrollPosition > 0) {
-			// Use a small delay to ensure the content is fully rendered
 			setTimeout(() => {
 				container.scrollTop = this.plugin.settings.scrollPosition;
 			}, 0);
@@ -225,25 +240,19 @@ export class StartPageView extends ItemView {
 			return [];
 		}
 
-		// Calculate the most recent time for each file (the maximum of modification time or access time)
 		const filesWithTime = allFiles.map((file) => {
 			let lastAccessTime = 0;
 
-			// Calculate access time based on position in the list of recently opened files
 			const openIndex = recentlyOpenedPaths.indexOf(file.path);
 			if (openIndex !== -1) {
-				// Convert the index to a timestamp, the earlier the file, the newer the time
-				// Use the current time minus the index minutes to simulate the access time
 				lastAccessTime = Date.now() - openIndex * 60 * 1000;
 			}
 
-			// Take the maximum value of modification time and access time
 			const lastTime = Math.max(file.stat.mtime, lastAccessTime);
 
 			return { file, lastTime };
 		});
 
-		// Sort by most recent time and return a specified number of files
 		return filesWithTime
 			.sort((a, b) => b.lastTime - a.lastTime)
 			.slice(0, limit)

--- a/src/views/stylesettingsmodal.ts
+++ b/src/views/stylesettingsmodal.ts
@@ -103,21 +103,18 @@ export default class StyleSettingsModal extends Modal {
 
         const trimmedValue = value.trim();
 
-        // 检查是否已有单位 (px, em, rem, %, vw, vh, pt, cm, mm, in, ex, ch, vmin, vmax)
         const hasUnit = /^(\d+\.?\d*)\s*(px|em|rem|%|vw|vh|pt|cm|mm|in|ex|ch|vmin|vmax)$/i.test(trimmedValue);
 
         if (hasUnit) {
             return trimmedValue;
         }
 
-        // 检查是否为纯数字（包括小数）
         const isNumber = /^\d+\.?\d*$/.test(trimmedValue);
 
         if (isNumber) {
             return trimmedValue + "px";
         }
 
-        // 其他情况（如 auto, inherit, initial, unset, 0 等）原样返回
         return trimmedValue;
     }
 


### PR DESCRIPTION
This commit:
- Updates package name and version to match obsidian-startpage 0.3.6
- Removes unnecessary Chinese and English comment blocks across all files
- Simplifies type and interface definitions by removing redundant inline comments
- Refactors keyboard event handling to use container-local listener instead of global
- Adds tabIndex to start page container for proper focus management
- Fixes default title navigation bar logic match
- Cleans up unused code and debug comments