### PR TITLE
feat(ui/settings): add toggle to show recently accessed notes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -55,6 +55,8 @@
     "open_start_page_new_tab_desc": "Open the start page in a new tab",
     "include_all_files_in_recent": "Include all files in recent notes",
     "include_all_files_in_recent_desc": "Include all types of files in the recent notes section, rather than only markdown files",
+    "show_recent_accessed_notes": "Show recently accessed notes",
+    "show_recent_accessed_notes_desc": "Include recently accessed notes in the recent notes list, sorted by access time",
     "show_title_navigation_bar": "Show title navigation bar",
     "show_title_navigation_bar_desc": "Show the title navigation bar on the start page",
     "show_title_navigation_bar_default": "Default",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -55,6 +55,8 @@
     "open_start_page_new_tab_desc": "在新标签页中打开启动首页",
     "include_all_files_in_recent": "在最近修改笔记中包含所有文件",
     "include_all_files_in_recent_desc": "在最近修改笔记中包含所有类型的文件，而不仅仅是Markdown文件",
+    "show_recent_accessed_notes": "显示最近访问的笔记",
+    "show_recent_accessed_notes_desc": "在最近笔记列表中包含最近访问过的笔记，按访问时间排序",
     "show_title_navigation_bar": "显示标题导航栏",
     "show_title_navigation_bar_desc": "在启动首页中显示标题导航栏",
     "show_title_navigation_bar_default": "默认",

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export const DEFAULT_SECTION_STYLE: SectionStyleSettings = {
 export interface StartPageSettings {
 	includeAllFilesInRecent: boolean;
 	recentNotesLimit: number;
+	showRecentAccessedNotes: boolean;
 	pinnedNotes: string[];
 	replaceNewTab: boolean;
 	showTitleNavigationBar: "default" | "show" | "hide";
@@ -79,6 +80,7 @@ export interface StartPageSettings {
 export const DEFAULT_SETTINGS: StartPageSettings = {
 	includeAllFilesInRecent: true,
 	recentNotesLimit: 10,
+	showRecentAccessedNotes: true,
 	pinnedNotes: [],
 	replaceNewTab: true,
 	showTitleNavigationBar: "default",

--- a/src/views/startpagesettingtab.ts
+++ b/src/views/startpagesettingtab.ts
@@ -77,6 +77,18 @@ export class StartPageSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName(t("show_recent_accessed_notes"))
+			.setDesc(t("show_recent_accessed_notes_desc"))
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.showRecentAccessedNotes);
+				toggle.onChange(async (value) => {
+					this.plugin.settings.showRecentAccessedNotes = value;
+					await this.plugin.saveSettings();
+					MyUtil.refreshStartPage(this.app);
+				});
+			});
+
+		new Setting(containerEl)
 			.setName(t("recent_notes_limit"))
 			.setDesc(t("recent_notes_limit_desc"))
 			.addDropdown((dropdown) => {

--- a/src/views/startpageview.ts
+++ b/src/views/startpageview.ts
@@ -244,7 +244,7 @@ export class StartPageView extends ItemView {
 			let lastAccessTime = 0;
 
 			const openIndex = recentlyOpenedPaths.indexOf(file.path);
-			if (openIndex !== -1) {
+			if (openIndex !== -1 && this.plugin.settings.showRecentAccessedNotes) {
 				lastAccessTime = Date.now() - openIndex * 60 * 1000;
 			}
 


### PR DESCRIPTION
Add a new plugin setting to control displaying recently accessed notes, add related locales and implement the filtering logic

Add new setting entry in settings tab, update default settings and localizations for both en and zh locales