### PR TITLE
feat(ui/notes): support middle-click and Ctrl/Cmd+Click to open notes…

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -45,6 +45,8 @@
     "manage": "Manage",
     "replace_new_tab": "Replace new tab",
     "replace_new_tab_desc": "When opening a new tab, replace it with Start Page",
+    "open_notes_in_new_tab": "Open notes in new tab",
+    "open_notes_in_new_tab_desc": "Left-click on pinned/recent notes will open them in a new tab instead of replacing the start page. You can always use Ctrl/Cmd+Click or middle-click to open in a new tab regardless of this setting.",
     "remove_from_pinned_notes": "Remove from pinned notes",
     "add_to_pinned_notes": "Add to pinned notes",
     "move_up": "Move up",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -45,6 +45,8 @@
     "manage": "管理",
     "replace_new_tab": "替换新标签页",
     "replace_new_tab_desc": "打开新标签页时，使用启动首页替换默认的新标签页",
+    "open_notes_in_new_tab": "在新标签页打开笔记",
+    "open_notes_in_new_tab_desc": "左键点击置顶/最近笔记时将在新标签页打开，而非替换启动首页。无论此设置如何，您始终可以通过鼠标中键或 Ctrl/Cmd+左键 在新标签页打开笔记。",
     "remove_from_pinned_notes": "从置顶笔记移除",
     "add_to_pinned_notes": "添加到置顶笔记",
     "move_up": "上移",

--- a/src/core/startpagecreator.ts
+++ b/src/core/startpagecreator.ts
@@ -1,5 +1,5 @@
 import { ID_STAT_TOTAL_NOTES, ID_STAT_TODAY_EDITED, ID_STAT_TOTAL_SIZE } from "@/types";
-import { App, TFolder, TFile, Menu, Platform } from "obsidian";
+import { App, TFolder, TFile, Menu, Platform, Keymap } from "obsidian";
 import StartPagePlugin from "@/main";
 import { t } from "@/i18n";
 import { VIEW_TYPE_START_PAGE, StartPageView } from "@/views/startpageview";
@@ -192,18 +192,41 @@ export default class StartPageCreator {
 		if (styleSettings.itemPadding) noteItem.style.padding = styleSettings.itemPadding;
 		if (styleSettings.itemMargin) noteItem.style.margin = styleSettings.itemMargin;
 
-		noteItem.addEventListener("click", async () => {
-			const existingLeaf = this.app.workspace.getLeavesOfType("markdown").find((leaf) => {
-				const state = leaf.view.getState();
-				return state["file"] === note.path;
+		noteItem.addEventListener("click", async (event: MouseEvent) => {
+				const modResult = Keymap.isModEvent(event);
+
+				const newLeaf = modResult || (this.plugin.settings.openNotesInNewTab ? "tab" : false);
+
+				if (newLeaf) {
+					this.app.workspace.openLinkText(note.path, "", newLeaf);
+				} else {
+					const existingLeaf = this.app.workspace.getLeavesOfType("markdown").find((leaf) => {
+						const state = leaf.view.getState();
+						return state["file"] === note.path;
+					});
+
+					if (existingLeaf) {
+						await this.app.workspace.revealLeaf(existingLeaf);
+					} else {
+						this.app.workspace.openLinkText(note.path, "", false);
+					}
+				}
 			});
 
-			if (existingLeaf) {
-				await this.app.workspace.revealLeaf(existingLeaf);
-			} else {
-				this.app.workspace.openLinkText(note.path, "", false);
-			}
-		});
+			noteItem.addEventListener("mousedown", (event: MouseEvent) => {
+				if (event.button === 1) {
+					event.preventDefault();
+					event.stopPropagation();
+				}
+			});
+
+			noteItem.addEventListener("mouseup", (event: MouseEvent) => {
+				if (event.button === 1) {
+					event.preventDefault();
+					event.stopPropagation();
+					this.app.workspace.openLinkText(note.path, "", "tab");
+				}
+			});
 
 		noteItem.addEventListener("mouseenter", (event) => {
 			this.app.workspace.trigger("hover-link", {
@@ -516,15 +539,16 @@ export default class StartPageCreator {
 		(this.container as HTMLElement).addEventListener("keydown", this.keyHandler);
 	}
 
-	private showSearchModal(): void {
-		const modal = new SearchModal(
-			this.app,
-			this.plugin,
-			(item: TFile) => {
-				this.app.workspace.openLinkText(item.path, "", false);
-			},
-			this.initialQuery
-		);
+		private showSearchModal(): void {
+			const modal = new SearchModal(
+				this.app,
+				this.plugin,
+				(item: TFile) => {
+					const newLeaf = this.plugin.settings.openNotesInNewTab ? "tab" : false;
+					this.app.workspace.openLinkText(item.path, "", newLeaf);
+				},
+				this.initialQuery
+			);
 		modal.open();
 		this.initialQuery = "";
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ export default class StartPagePlugin extends Plugin {
 				recentNotesLimit: typeof savedData.recentNotesLimit === "number" ? savedData.recentNotesLimit : 10,
 				includeAllFilesInRecent: typeof savedData.includeAllFilesInRecent === "boolean" ? savedData.includeAllFilesInRecent : true,
 				replaceNewTab: typeof savedData.replaceNewTab === "boolean" ? savedData.replaceNewTab : true,
+				openNotesInNewTab: typeof savedData.openNotesInNewTab === "boolean" ? savedData.openNotesInNewTab : false,
 				showTitleNavigationBar: ["default", "show", "hide"].includes(savedData.showTitleNavigationBar) ? savedData.showTitleNavigationBar : "default",
 				showCustomFooterText: typeof savedData.showCustomFooterText === "boolean" ? savedData.showCustomFooterText : false,
 				useRandomFooterText: typeof savedData.useRandomFooterText === "boolean" ? savedData.useRandomFooterText : false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface StartPageSettings {
 	showRecentAccessedNotes: boolean;
 	pinnedNotes: string[];
 	replaceNewTab: boolean;
+	openNotesInNewTab: boolean;
 	showTitleNavigationBar: "default" | "show" | "hide";
 	showCustomFooterText: boolean;
 	useRandomFooterText: boolean;
@@ -82,8 +83,9 @@ export const DEFAULT_SETTINGS: StartPageSettings = {
 	recentNotesLimit: 10,
 	showRecentAccessedNotes: true,
 	pinnedNotes: [],
-	replaceNewTab: true,
-	showTitleNavigationBar: "default",
+		replaceNewTab: true,
+		openNotesInNewTab: false,
+		showTitleNavigationBar: "default",
 	showCustomFooterText: false,
 	useRandomFooterText: false,
 	todayRandomEnFooterText: "",

--- a/src/views/startpagesettingtab.ts
+++ b/src/views/startpagesettingtab.ts
@@ -154,17 +154,28 @@ export class StartPageSettingTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName(t("new_tab_settings_heading"))
             .setHeading();
-        new Setting(containerEl)
-			.setName(t("replace_new_tab"))
-			.setDesc(t("replace_new_tab_desc"))
-			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.replaceNewTab);
-				toggle.onChange(async (value) => {
-					this.plugin.settings.replaceNewTab = value;
-					await this.plugin.saveSettings();
+		new Setting(containerEl)
+				.setName(t("replace_new_tab"))
+				.setDesc(t("replace_new_tab_desc"))
+				.addToggle((toggle) => {
+					toggle.setValue(this.plugin.settings.replaceNewTab);
+					toggle.onChange(async (value) => {
+						this.plugin.settings.replaceNewTab = value;
+						await this.plugin.saveSettings();
+					});
 				});
-			});
-    }
+
+			new Setting(containerEl)
+				.setName(t("open_notes_in_new_tab"))
+				.setDesc(t("open_notes_in_new_tab_desc"))
+				.addToggle((toggle) => {
+					toggle.setValue(this.plugin.settings.openNotesInNewTab);
+					toggle.onChange(async (value) => {
+						this.plugin.settings.openNotesInNewTab = value;
+						await this.plugin.saveSettings();
+					});
+				});
+	    }
 
     private createSearchSettings(containerEl: HTMLElement) {
         new Setting(containerEl)


### PR DESCRIPTION
… in new tab, add setting for left-click behavior

- Use Keymap.isModEvent() to detect modifier keys and middle-click
- Add mousedown/mouseup handlers for middle-click (prevent autoscroll)
- Add openNotesInNewTab setting (default false) to control left-click behavior
- Search modal respects openNotesInNewTab setting
- Add i18n keys for English and Chinese locales

Closes #28