### PR TITLE
fix: exclusion settings not persisting after restart (fixes #23)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -91,8 +91,12 @@ export default class StartPagePlugin extends Plugin {
 				showStatBar: typeof savedData.showStatBar === "boolean" ? savedData.showStatBar : true,
 				lastVersionCheck: typeof savedData.lastVersionCheck === "number" ? savedData.lastVersionCheck : 0,
 				latestVersion: typeof savedData.latestVersion === "string" ? savedData.latestVersion : "",
-				searchExcludePaths: Array.isArray(savedData.excludeList) ? savedData.excludeList : [],
-				searchExcludeExtensions: Array.isArray(savedData.excludeExtensions) ? savedData.excludeExtensions : [],
+				searchExcludePaths: Array.isArray(savedData.searchExcludePaths)
+						? savedData.searchExcludePaths
+						: (Array.isArray(savedData.excludeList) ? savedData.excludeList : []),
+					searchExcludeExtensions: Array.isArray(savedData.searchExcludeExtensions)
+						? savedData.searchExcludeExtensions
+						: (Array.isArray(savedData.excludeExtensions) ? savedData.excludeExtensions : []),
 				pinnedNotesStyle:
 					typeof savedData.pinnedNotesStyle === "object"
 						? { ...DEFAULT_SETTINGS.pinnedNotesStyle, ...savedData.pinnedNotesStyle }


### PR DESCRIPTION
loadSettings read exclusion settings from old field names (excludeList/excludeExtensions), but saveSettings writes to new names (searchExcludePaths/searchExcludeExtensions). Fixed by reading new names first, falling back to old names for backward compatibility.